### PR TITLE
Remove bundler config

### DIFF
--- a/.bundle/config
+++ b/.bundle/config
@@ -1,3 +1,0 @@
----
-BUNDLE_PATH: ".bundle"
-BUNDLE_SPECIFIC_PLATFORM: "true"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 - Release via RubyGems as `runger_byebug`.
+- Delete `.bundle/config`.
 
 ### Changed
 


### PR DESCRIPTION
The `BUNDLE_PATH` causes a problem for `runger_release_assistant` because it causes many version files to be found in the repository directory (for gems in `.bundle/`). I don't know if `BUNDLE_SPECIFIC_PLATFORM` is good, bad, or neutral. For simplicity, I will go ahead and remove it, as I am not aware of much good and I don't think there will be much (if any) harm.